### PR TITLE
Adding pow multiplier in VolumetricFog.fx

### DIFF
--- a/Shaders/VolumetricFog.fx
+++ b/Shaders/VolumetricFog.fx
@@ -90,9 +90,9 @@ uniform float IntensityPow <
 	ui_step = 0.01;
 	ui_type = "slider";
 	ui_label = "Intensity Pow";
-	ui_tooltip = "Pow multiplier for fog depth.\n"
-				  "Increasing this will decrease the intensity of the fog at lower depth,\n"
-				  "useful to prevent clarity of closer elements from diminishing.";
+	ui_tooltip = "Pow multiplier for fog depth\n"
+				  "Increasing this will decrease the intensity of the fog at lower depth\n"
+				  "Useful to prevent clarity of closer elements from diminishing.";
 	ui_category = "Blending";
 > = 1;
 

--- a/Shaders/VolumetricFog.fx
+++ b/Shaders/VolumetricFog.fx
@@ -84,6 +84,18 @@ uniform float MaxIntensity <
 	ui_category = "Blending";
 > = 0.8;
 
+uniform float IntensityPow <
+	ui_max = 6;
+	ui_min = 0;
+	ui_step = 0.01;
+	ui_type = "slider";
+	ui_label = "Intensity Pow";
+	ui_tooltip = "Pow multiplier for fog depth.\n"
+				  "Increasing this will decrease the intensity of the fog at lower depth,\n"
+				  "useful to prevent clarity of closer elements from diminishing.";
+	ui_category = "Blending";
+> = 1;
+
 uniform float Exposure <
 	ui_type = "slider";
 	ui_max = 2;
@@ -220,7 +232,7 @@ float3 Blend( float4 Postion : SV_Position, float2 texcoord : TEXCOORD0) : SV_Ta
 	
 	float3 back= tex2D(sTexColor, texcoord).rgb;
 	
-	float coeff = min( depth * Intensity, MaxIntensity);
+	float coeff = min( pow(depth, IntensityPow) * Intensity, MaxIntensity);
 	
 	return lerp( back, fog.rgb, coeff);
 }


### PR DESCRIPTION
In VolumetricFog.fx, this allows the fog intensity related to distance to have a pow multiplier.

I'm suggesting this because although this shader makes games look more cinematic, if the game is somewhat competitive, the decreased clarity at lower depth makes me disable the shader. This pow function is a good middle ground to that issue.

I kept the default value for IntensityPow as 1, so there won't be any changes to users who update this shader. For testing purposes, in a certain racing game I used IntensityPow as 2.25, so it still maintained a lot of clarity up close while adding this beautiful cinematic background fog effect.